### PR TITLE
Doc's brief element isn't actually required

### DIFF
--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -353,7 +353,6 @@ structField el
     | el `named` "reply" = fail "" -- handled separate
 
     | el `named` "doc" = do
-        brief <- liftM strContent $ el `child` "brief"
         fields <- el `children` "field"
         let mkField = \x -> fmap (\y -> (y, strContent x)) $ x `attr` "name"
             fields' = Map.fromList $ catMaybes $ map mkField fields
@@ -361,6 +360,7 @@ structField el
             sees' = catMaybes $ flip map sees $ \s -> do typ <- s `attr` "type"
                                                          name <- s `attr` "name"
                                                          return (typ, name)
+            brief = fmap strContent $ findChild (unqual "brief") el
         return $ Doc brief fields' sees'
 
     | el `named` "fd" = do
@@ -467,11 +467,6 @@ children :: MonadPlus m => Element -> String -> m [Element]
       some -> return $ onlyElems some
     where p (Elem (Element n _ _ _)) | n == unqual name = True
           p _ = False
-
-child :: MonadPlus m => Element -> String -> m Element
-e `child` n = case findChild (unqual n) e of
-                Just el -> return el
-                _ -> mzero
 
 -- adapted from Network.CGI.Protocol
 readM :: (MonadPlus m, Read a) => String -> m a

--- a/Data/XCB/Pretty.hs
+++ b/Data/XCB/Pretty.hs
@@ -112,7 +112,7 @@ instance Pretty a => Pretty (GenStructElem a) where
     toDoc (Doc brief fields see)
         = text "Doc" <+>
           text "::" <+>
-          text "brief=" <+> text brief <+> text ";" <+>
+          text "brief=" <+> text (fromMaybe "" brief) <+>
           text "fields=" <+>
           hsep (punctuate (char ',') $ joinWith ":" $ Map.toList fields) <+>
           text ";" <+>

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -97,7 +97,7 @@ data GenStructElem typ
     | ExprField Name typ (Expression typ)
     | ValueParam typ Name (Maybe MaskPadding) ListName
     | Switch Name (Expression typ) [GenBitCase typ]
-    | Doc String (Map Name String) [(String, String)]
+    | Doc (Maybe String) (Map Name String) [(String, String)]
     | Fd String
  deriving (Show, Functor)
 


### PR DESCRIPTION
Sorry about that, I didn't realize not all elements had a <brief>, but apparently they don't.
