### PR TITLE
allow empty error structs

### DIFF
--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -259,7 +259,6 @@ xerror el = do
   name <- el `attr` "name"
   number <- el `attr` "number" >>= readM
   fields <- mapM structField $ elChildren el
-  guard $ not $ null fields
   return $ XError name number fields
 
 


### PR DESCRIPTION
XCB has empty error structs [1], (and in xv, and a few other spots), so we
should actually render these even if they're empty.

[1]: http://cgit.freedesktop.org/xcb/proto/tree/src/render.xml#n135