### PR TITLE
Update for xcb-proto 1.12

### DIFF
--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -78,7 +78,7 @@ allModules = fst `liftM` ask
 extractAlignment :: (MonadPlus m, Functor m) => [Element] -> m (Maybe Alignment, [Element])
 extractAlignment (el : xs) | el `named` "required_start_align" = do
                                align <- el `attr` "align" >>= readM
-                               offset <- el `attr` "offset" >>= readM
+                               let offset = el `attr` "offset" >>= readM
                                return (Just (Alignment align offset), xs)
                            | otherwise = return (Nothing, el : xs)
 extractAlignment xs = return (Nothing, xs)

--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -428,6 +428,8 @@ expression el | el `named` "fieldref"
               | el `named` "sumof" = do
                     ref <- el `attr` "ref"
                     return $ SumOf ref
+              | el `named` "paramref"
+                    =  return $ ParamRef $ strContent el
               | otherwise =
                   let nm = elName el
                   in error $ "Unknown epression " ++ show nm ++ " in Data.XCB.FromXML.expression"

--- a/Data/XCB/Pretty.hs
+++ b/Data/XCB/Pretty.hs
@@ -90,6 +90,7 @@ instance Pretty a => Pretty (Expression a) where
                         ]
     toDoc (Unop op expr)
         = parens $ toDoc op <> toDoc expr
+    toDoc (ParamRef n) = toDoc n
 
 instance Pretty a => Pretty (GenStructElem a) where
     toDoc (Pad n) = braces $ toDoc n <+> text "bytes"

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -139,6 +139,7 @@ data Expression typ
     | SumOf Name -- ^Note sure. The argument should be a reference to a list
     | Op Binop (Expression typ) (Expression typ) -- ^A binary opeation
     | Unop Unop (Expression typ) -- ^A unary operation
+    | ParamRef Name -- ^I think this is the name of an argument passed to the request. See fffbd04d63 in xcb-proto.
  deriving (Show, Functor)
 
 -- |Supported Binary operations.

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -30,7 +30,7 @@ module Data.XCB.Types
     , GenXDecl ( .. )
     , GenStructElem ( .. )
     , GenBitCase ( .. )
-    , GenXReply
+    , GenXReply ( .. )
     , GenXidUnionElem ( .. )
     , EnumElem ( .. )
     , Expression ( .. )
@@ -44,6 +44,7 @@ module Data.XCB.Types
     , MaskName
     , ListName
     , MaskPadding
+    , Alignment ( .. )
     ) where
 
 import Data.Map
@@ -78,16 +79,16 @@ type XEnumElem = EnumElem Type
 -- |The different types of declarations which can be made in one of the
 -- XML files.
 data GenXDecl typ
-    = XStruct  Name [GenStructElem typ]
+    = XStruct  Name (Maybe Alignment) [GenStructElem typ]
     | XTypeDef Name typ
-    | XEvent Name Int [GenStructElem typ] (Maybe Bool)  -- ^ The boolean indicates if the event includes a sequence number.
-    | XRequest Name Int [GenStructElem typ] (Maybe (GenXReply typ))
+    | XEvent Name Int (Maybe Alignment) [GenStructElem typ] (Maybe Bool)  -- ^ The boolean indicates if the event includes a sequence number.
+    | XRequest Name Int (Maybe Alignment) [GenStructElem typ] (Maybe (GenXReply typ))
     | XidType  Name
     | XidUnion  Name [GenXidUnionElem typ]
     | XEnum Name [EnumElem typ]
-    | XUnion Name [GenStructElem typ]
+    | XUnion Name (Maybe Alignment) [GenStructElem typ]
     | XImport Name
-    | XError Name Int [GenStructElem typ]
+    | XError Name Int (Maybe Alignment) [GenStructElem typ]
  deriving (Show, Functor)
 
 data GenStructElem typ
@@ -96,20 +97,21 @@ data GenStructElem typ
     | SField Name typ (Maybe (EnumVals typ)) (Maybe (MaskVals typ))
     | ExprField Name typ (Expression typ)
     | ValueParam typ Name (Maybe MaskPadding) ListName
-    | Switch Name (Expression typ) [GenBitCase typ]
+    | Switch Name (Expression typ) (Maybe Alignment) [GenBitCase typ]
     | Doc (Maybe String) (Map Name String) [(String, String)]
     | Fd String
  deriving (Show, Functor)
 
 data GenBitCase typ
-    = BitCase (Maybe Name) (Expression typ) [GenStructElem typ]
+    = BitCase (Maybe Name) (Expression typ) (Maybe Alignment) [GenStructElem typ]
  deriving (Show, Functor)
 
 type EnumVals typ = typ
 type MaskVals typ = typ
 
 type Name = String
-type GenXReply typ = [GenStructElem typ]
+data GenXReply typ = GenXReply (Maybe Alignment) [GenStructElem typ]
+ deriving (Show, Functor)
 type Ref = String
 type MaskName = Name
 type ListName = Name
@@ -150,3 +152,5 @@ data Binop = Add
 
 data Unop = Complement
  deriving (Show)
+
+data Alignment = Alignment Int Int deriving (Show)

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -154,4 +154,4 @@ data Binop = Add
 data Unop = Complement
  deriving (Show)
 
-data Alignment = Alignment Int Int deriving (Show)
+data Alignment = Alignment Int (Maybe Int) deriving (Show)


### PR DESCRIPTION
Hi,

So xcb-proto adds a few new elements, which don't parse with xcb-types as is. I've updated xcb-types to parse 1.12, but that required some new additions to the API. It would be handy if we could tag another version with these changes, but let me know if they're too ugly and we can figure out something.

FWIW, the new XCB maintainer seems keen on adding stuff like this, so there may be more of these in the future.
