### PR TITLE
Add flag for xge events

### DIFF
--- a/Data/XCB/Pretty.hs
+++ b/Data/XCB/Pretty.hs
@@ -187,11 +187,11 @@ instance Pretty a => Pretty (GenXDecl a) where
                                     ,text "as"
                                     ,toDoc typ
                                     ]
-    toDoc (XEvent nm n alignment xge elems (Just True)) =
+    toDoc (XEvent nm n alignment _ elems (Just True)) =
         hang (text "Event:" <+> text nm <> char ',' <> toDoc n <+> toDoc alignment <+>
              parens (text "No sequence number")) 2 $
              vcat $ map toDoc elems
-    toDoc (XEvent nm n alignment xge elems _) =
+    toDoc (XEvent nm n alignment _ elems _) =
         hang (text "Event:" <+> text nm <> char ',' <> toDoc n <+> toDoc alignment) 2 $
              vcat $ map toDoc elems
     toDoc (XRequest nm n alignment elems mrep) = 

--- a/Data/XCB/Pretty.hs
+++ b/Data/XCB/Pretty.hs
@@ -187,11 +187,11 @@ instance Pretty a => Pretty (GenXDecl a) where
                                     ,text "as"
                                     ,toDoc typ
                                     ]
-    toDoc (XEvent nm n alignment elems (Just True)) =
+    toDoc (XEvent nm n alignment xge elems (Just True)) =
         hang (text "Event:" <+> text nm <> char ',' <> toDoc n <+> toDoc alignment <+>
              parens (text "No sequence number")) 2 $
              vcat $ map toDoc elems
-    toDoc (XEvent nm n alignment elems _) =
+    toDoc (XEvent nm n alignment xge elems _) =
         hang (text "Event:" <+> text nm <> char ',' <> toDoc n <+> toDoc alignment) 2 $
              vcat $ map toDoc elems
     toDoc (XRequest nm n alignment elems mrep) = 

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -82,7 +82,7 @@ type XEnumElem = EnumElem Type
 data GenXDecl typ
     = XStruct  Name (Maybe Alignment) [GenStructElem typ]
     | XTypeDef Name typ
-    | XEvent Name Int (Maybe Alignment) [GenStructElem typ] (Maybe Bool)  -- ^ The boolean indicates if the event includes a sequence number.
+    | XEvent Name Int (Maybe Alignment) (Maybe Bool) [GenStructElem typ] (Maybe Bool)  -- ^ bools: #1 if xge is true; #2  if the event includes a sequence number.
     | XRequest Name Int (Maybe Alignment) [GenStructElem typ] (Maybe (GenXReply typ))
     | XidType  Name
     | XidUnion  Name [GenXidUnionElem typ]


### PR DESCRIPTION
This PR adds support for reading the `xge` attribute in xcbproto. This has been added to allow the python `xcffib` library correctly handle events provided by extensions (see https://github.com/tych0/xcffib/pull/126).

This was my first go doing anything in Haskell so I apologise in advance. I'm happy to be corrected if there's a better way to do this.

