### PR TITLE
support both 'bytes' and 'align' pad types

### DIFF
--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -349,8 +349,10 @@ structField el
         return $ SField name typ enum mask
 
     | el `named` "pad" = do
-        bytes <- el `attr` "bytes" >>= readM
-        return $ Pad bytes
+        let bytes = liftM (Pad PadBytes) $ el `attr` "bytes" >>= readM
+        let align = liftM (Pad PadAlignment) $ el `attr` "align" >>= readM
+
+        return $ head $ catMaybes $ [bytes, align]
 
     | el `named` "list" = do
         typ <- liftM mkType $ el `attr` "type"

--- a/Data/XCB/Pretty.hs
+++ b/Data/XCB/Pretty.hs
@@ -97,8 +97,12 @@ instance Pretty a => Pretty (Expression a) where
         = parens $ toDoc op <> toDoc expr
     toDoc (ParamRef n) = toDoc n
 
+instance Pretty PadType where
+    pretty PadBytes = "bytes"
+    pretty PadAlignment = "align"
+
 instance Pretty a => Pretty (GenStructElem a) where
-    toDoc (Pad n) = braces $ toDoc n <+> text "bytes"
+    toDoc (Pad typ n) = braces $ toDoc n <+> toDoc typ
     toDoc (List nm typ len enums)
         = text nm <+> text "::" <+> brackets (toDoc typ <+> toDoc enums) <+> toDoc len
     toDoc (SField nm typ enums mask) = hsep [text nm

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -46,6 +46,7 @@ module Data.XCB.Types
     , MaskPadding
     , Alignment ( .. )
     , AllowedEvent ( .. )
+    , PadType ( .. )
     ) where
 
 import Data.Map
@@ -93,8 +94,13 @@ data GenXDecl typ
     | XEventStruct Name [AllowedEvent]
  deriving (Show, Functor)
 
+data PadType
+    = PadBytes
+    | PadAlignment
+ deriving (Show)
+
 data GenStructElem typ
-    = Pad Int
+    = Pad PadType Int
     | List Name typ (Maybe (Expression typ)) (Maybe (EnumVals typ))
     | SField Name typ (Maybe (EnumVals typ)) (Maybe (MaskVals typ))
     | ExprField Name typ (Expression typ)


### PR DESCRIPTION
before this, we simply swallowed <pad align="N" /> elements, which was unhelpful. Let's actually render them, and indicate which kind of padding they represent.