### PR TITLE
Fix error: Not in scope 'MonadFail' Data/XCB/FromXML.hs

### DIFF
--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -15,6 +15,7 @@
 --
 -- There is no provision for preserving the event copy and error copy
 -- declarations - the copies are handled during parsing.
+{-# LANGUAGE CPP #-}
 module Data.XCB.FromXML(fromFiles
                        ,fromStrings
                        ) where
@@ -30,8 +31,9 @@ import Data.Maybe (catMaybes, mapMaybe, maybeToList)
 
 import Control.Monad (MonadPlus (mzero, mplus), guard, liftM, liftM2)
 import Control.Monad.Reader (ReaderT, runReaderT, ask, lift, withReaderT)
+#if __GLASGOW_HASKELL__ < 900
 import Control.Monad.Fail (MonadFail)
-
+#endif
 import System.IO (openFile, IOMode (ReadMode), hSetEncoding, utf8, hGetContents)
 
 -- |Process the listed XML files.

--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -30,6 +30,7 @@ import Data.Maybe (catMaybes, mapMaybe, maybeToList)
 
 import Control.Monad (MonadPlus (mzero, mplus), guard, liftM, liftM2)
 import Control.Monad.Reader (ReaderT, runReaderT, ask, lift, withReaderT)
+import Control.Monad.Fail (MonadFail)
 
 import System.IO (openFile, IOMode (ReadMode), hSetEncoding, utf8, hGetContents)
 


### PR DESCRIPTION
Data/XCB/FromXML.hs:342:17: error:
    Not in scope: type constructor or class `MonadFail'
    |
342 | structField :: (MonadFail m, MonadPlus m, Functor m) => Element -> m StructElem
    |                 ^^^^^^^^^

Data/XCB/FromXML.hs:411:13: error:
    Not in scope: type constructor or class `MonadFail'
    |
411 | bitCase :: (MonadFail m, MonadPlus m, Functor m) => Element -> m BitCase
    |             ^^^^^^^^^

Data/XCB/FromXML.hs:423:16: error:
    Not in scope: type constructor or class `MonadFail'
    |
423 | expression :: (MonadFail m, MonadPlus m, Functor m) => Element -> m XExpression
    |                ^^^^^^^^^

GHC 8.6.4

Here is a project that had the same error:
https://github.com/i-am-tom/holmes/issues/8