### PR TITLE
add support for xkb.xml

### DIFF
--- a/Data/XCB/FromXML.hs
+++ b/Data/XCB/FromXML.hs
@@ -414,11 +414,11 @@ structField el
 bitCase :: (MonadFail m, MonadPlus m, Functor m) => Element -> m BitCase
 bitCase el | el `named` "bitcase" || el `named` "case" = do
               let mName = el `attr` "name"
-              (exprEl, fieldEls) <- unconsChildren el
-              expr <- expression exprEl
+              let (exprEls, fieldEls) = takeEnumrefs $ elChildren el
+              exprs <- mapM expression exprEls
               (alignment, xs) <- extractAlignment $ fieldEls
               fields <- mapM structField xs
-              return $ BitCase mName expr alignment fields
+              return $ BitCase mName exprs alignment fields
            | otherwise =
               let name = elName el
               in error $ "Invalid bitCase: " ++ show name
@@ -488,6 +488,12 @@ unconsChildren el
     = case elChildren el of
         (x:xs) -> return (x,xs)
         _ -> mzero
+
+takeEnumrefs :: [Element] -> ([Element], [Element])
+takeEnumrefs [] = ([], [])
+takeEnumrefs (x:xs) =
+    let (ys, zs) = takeEnumrefs xs
+    in if x `named` "enumref" then (x:ys, zs) else (ys, x:zs)
 
 listToM :: MonadPlus m => [a] -> m a
 listToM [] = mzero

--- a/Data/XCB/Pretty.hs
+++ b/Data/XCB/Pretty.hs
@@ -158,18 +158,18 @@ instance Pretty a => Pretty (GenStructElem a) where
 
 
 instance Pretty a => Pretty (GenBitCase a) where
-    toDoc (BitCase name expr alignment fields)
+    toDoc (BitCase name exprs alignment fields)
         = vcat
-           [ bitCaseHeader name expr
+           [ bitCaseHeader name exprs
            , toDoc alignment
            , braces (vcat (map toDoc fields))
            ]
 
-bitCaseHeader :: Pretty a => Maybe Name -> Expression a -> Doc
-bitCaseHeader Nothing expr =
-    text "bitcase" <> parens (toDoc expr)
-bitCaseHeader (Just name) expr =
-    text "bitcase" <> parens (toDoc expr) <> brackets (text name)
+bitCaseHeader :: Pretty a => Maybe Name -> [Expression a] -> Doc
+bitCaseHeader Nothing exprs =
+    text "bitcase" <> parens (hcat (map toDoc exprs))
+bitCaseHeader (Just name) exprs =
+    text "bitcase" <> parens (hcat (map toDoc exprs)) <> brackets (text name)
 
 instance Pretty Alignment where
     toDoc (Alignment align offset) = text "alignment" <+>

--- a/Data/XCB/Types.hs
+++ b/Data/XCB/Types.hs
@@ -112,7 +112,10 @@ data GenStructElem typ
  deriving (Show, Functor)
 
 data GenBitCase typ
-    = BitCase (Maybe Name) (Expression typ) (Maybe Alignment) [GenStructElem typ]
+    -- All requests with the exception of GetKbdByName seem to have exactly 1
+    -- expression value, but GetKbdByNameReply has multiple, see xcbproto
+    -- commit b3b5e029e7ad ("XKB: Fix GetKbdByName") for details.
+    = BitCase (Maybe Name) [Expression typ] (Maybe Alignment) [GenStructElem typ]
  deriving (Show, Functor)
 
 type EnumVals typ = typ


### PR DESCRIPTION
xkb.xml exports multiple enumrefs for its BitCases (the semantics are... unclear, viz. the xproto commit I linked in the comment), so we need to support grabbing multiple enumrefs instead of just one, and exporting those to users.

This parses xcb-proto 1.17.0's xkb.xml correctly for me.